### PR TITLE
Add variable output size support for BLAKE2 implementations

### DIFF
--- a/benches/blake2.rs
+++ b/benches/blake2.rs
@@ -1,10 +1,10 @@
 use criterion::Criterion;
-use stedy::{blake2b, blake2s};
+use stedy::{blake2b512, blake2s256};
 
 pub fn bench(c: &mut Criterion) {
     let message = [72, 105, 32, 84, 104, 101, 114, 101];
 
-    c.bench_function("blake2b", |b| b.iter(|| blake2b(&message)));
+    c.bench_function("blake2b", |b| b.iter(|| blake2b512(&message)));
 
-    c.bench_function("blake2s", |b| b.iter(|| blake2s(&message)));
+    c.bench_function("blake2s", |b| b.iter(|| blake2s256(&message)));
 }

--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -3,13 +3,13 @@ use crate::{
     traits::{Digest, Hasher, Init, KeyInit},
 };
 
-pub struct Blake2b {
+pub struct Blake2b<const N: usize> {
     h: [u64; 8],
     t: u128,
     block: Block<128>,
 }
 
-impl Blake2b {
+impl<const N: usize> Blake2b<N> {
     pub fn new(key: Option<&[u8]>) -> Self {
         let mut state = Self {
             h: Self::IV,
@@ -29,7 +29,7 @@ impl Blake2b {
         }
     }
 
-    pub fn finalize_into(mut self, digest: &mut [u8; 64]) {
+    pub fn finalize_into(mut self, digest: &mut [u8; N]) {
         let remaining = self.block.remaining();
         let mut block = [0u8; 128];
         block[..remaining.len()].copy_from_slice(remaining);
@@ -41,35 +41,51 @@ impl Blake2b {
         }
     }
 
-    pub fn finalize(self) -> [u8; 64] {
-        let mut digest = [0u8; 64];
+    pub fn finalize(self) -> [u8; N] {
+        let mut digest = [0u8; N];
         self.finalize_into(&mut digest);
         digest
     }
 }
 
-pub fn blake2b(message: &[u8]) -> [u8; 64] {
-    let mut hasher = Blake2b::new(None);
+pub fn blake2b<const N: usize>(message: &[u8]) -> [u8; N] {
+    let mut hasher = Blake2b::<N>::new(None);
     hasher.update(message);
     hasher.finalize()
 }
 
-impl Init for Blake2b {
+pub fn blake2b512(message: &[u8]) -> [u8; 64] {
+    blake2b::<64>(message)
+}
+
+pub fn blake2b384(message: &[u8]) -> [u8; 48] {
+    blake2b::<48>(message)
+}
+
+pub fn blake2b256(message: &[u8]) -> [u8; 32] {
+    blake2b::<32>(message)
+}
+
+pub fn blake2b160(message: &[u8]) -> [u8; 20] {
+    blake2b::<20>(message)
+}
+
+impl<const N: usize> Init for Blake2b<N> {
     fn new() -> Self {
         Self::new(None)
     }
 }
 
-impl KeyInit for Blake2b {
+impl<const N: usize> KeyInit for Blake2b<N> {
     fn new(key: &[u8]) -> Self {
         Self::new(Some(key))
     }
 }
 
-impl Digest for Blake2b {
-    const OUTPUT_SIZE: usize = 64;
+impl<const N: usize> Digest for Blake2b<N> {
+    const OUTPUT_SIZE: usize = N;
 
-    type Output = [u8; Self::OUTPUT_SIZE];
+    type Output = [u8; N];
 
     fn update(&mut self, message: &[u8]) {
         self.update(message);
@@ -84,13 +100,13 @@ impl Digest for Blake2b {
     }
 }
 
-impl Hasher for Blake2b {
+impl<const N: usize> Hasher for Blake2b<N> {
     const BLOCK_SIZE: usize = 128;
 
-    type Block = [u8; Self::BLOCK_SIZE];
+    type Block = [u8; 128];
 }
 
-impl Blake2b {
+impl<const N: usize> Blake2b<N> {
     const IV: [u64; 8] = [
         0x6a09e667f3bcc908,
         0xbb67ae8584caa73b,
@@ -117,7 +133,8 @@ impl Blake2b {
     fn init(&mut self, key: Option<&[u8]>) {
         let key = key.unwrap_or_default();
         let kk = key.len().min(64);
-        self.h[0] ^= 0x01010000 ^ ((kk as u64) << 8) ^ 64;
+        let nn = N.min(64);
+        self.h[0] ^= 0x01010000 ^ ((kk as u64) << 8) ^ (nn as u64);
         if !key.is_empty() {
             let mut block = [0u8; 128];
             block[..kk].copy_from_slice(&key[..kk]);
@@ -177,8 +194,8 @@ mod tests {
     // https://datatracker.ietf.org/doc/html/rfc7693
 
     #[test]
-    fn test_blake2b() {
-        let digest = blake2b(b"abc");
+    fn test_blake2b512() {
+        let digest = blake2b512(b"abc");
         assert_eq!(
             digest,
             [

--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -1,6 +1,7 @@
 use crate::{
     block::Block,
-    traits::{Digest, Hasher, Init, KeyInit},
+    traits::{Digest, Hasher, Init, KeyInit, Mac},
+    verify::verify,
 };
 
 pub struct Blake2b<const N: usize> {
@@ -45,6 +46,10 @@ impl<const N: usize> Blake2b<N> {
         let mut digest = [0u8; N];
         self.finalize_into(&mut digest);
         digest
+    }
+
+    pub fn verify(self, code: &[u8; N]) -> bool {
+        verify(code, &self.finalize())
     }
 }
 
@@ -104,6 +109,12 @@ impl<const N: usize> Hasher for Blake2b<N> {
     const BLOCK_SIZE: usize = 128;
 
     type Block = [u8; 128];
+}
+
+impl<const N: usize> Mac for Blake2b<N> {
+    fn verify(self, code: &[u8; N]) -> bool {
+        self.verify(code)
+    }
 }
 
 impl<const N: usize> Blake2b<N> {

--- a/src/blake2s.rs
+++ b/src/blake2s.rs
@@ -3,13 +3,13 @@ use crate::{
     traits::{Digest, Hasher, Init, KeyInit},
 };
 
-pub struct Blake2s {
+pub struct Blake2s<const N: usize> {
     h: [u32; 8],
     t: u64,
     block: Block<64>,
 }
 
-impl Blake2s {
+impl<const N: usize> Blake2s<N> {
     pub fn new(key: Option<&[u8]>) -> Self {
         let mut state = Self {
             h: Self::IV,
@@ -29,7 +29,7 @@ impl Blake2s {
         }
     }
 
-    pub fn finalize_into(mut self, digest: &mut [u8; 32]) {
+    pub fn finalize_into(mut self, digest: &mut [u8; N]) {
         let remaining = self.block.remaining();
         let mut block = [0u8; 64];
         block[..remaining.len()].copy_from_slice(remaining);
@@ -41,35 +41,51 @@ impl Blake2s {
         }
     }
 
-    pub fn finalize(self) -> [u8; 32] {
-        let mut digest = [0u8; 32];
+    pub fn finalize(self) -> [u8; N] {
+        let mut digest = [0u8; N];
         self.finalize_into(&mut digest);
         digest
     }
 }
 
-pub fn blake2s(message: &[u8]) -> [u8; 32] {
-    let mut hasher = Blake2s::new(None);
+pub fn blake2s<const N: usize>(message: &[u8]) -> [u8; N] {
+    let mut hasher = Blake2s::<N>::new(None);
     hasher.update(message);
     hasher.finalize()
 }
 
-impl Init for Blake2s {
+pub fn blake2s256(message: &[u8]) -> [u8; 32] {
+    blake2s::<32>(message)
+}
+
+pub fn blake2s224(message: &[u8]) -> [u8; 28] {
+    blake2s::<28>(message)
+}
+
+pub fn blake2s160(message: &[u8]) -> [u8; 20] {
+    blake2s::<20>(message)
+}
+
+pub fn blake2s128(message: &[u8]) -> [u8; 16] {
+    blake2s::<16>(message)
+}
+
+impl<const N: usize> Init for Blake2s<N> {
     fn new() -> Self {
         Self::new(None)
     }
 }
 
-impl KeyInit for Blake2s {
+impl<const N: usize> KeyInit for Blake2s<N> {
     fn new(key: &[u8]) -> Self {
         Self::new(Some(key))
     }
 }
 
-impl Digest for Blake2s {
-    const OUTPUT_SIZE: usize = 32;
+impl<const N: usize> Digest for Blake2s<N> {
+    const OUTPUT_SIZE: usize = N;
 
-    type Output = [u8; Self::OUTPUT_SIZE];
+    type Output = [u8; N];
 
     fn update(&mut self, message: &[u8]) {
         self.update(message);
@@ -84,13 +100,13 @@ impl Digest for Blake2s {
     }
 }
 
-impl Hasher for Blake2s {
+impl<const N: usize> Hasher for Blake2s<N> {
     const BLOCK_SIZE: usize = 64;
 
-    type Block = [u8; Self::BLOCK_SIZE];
+    type Block = [u8; 64];
 }
 
-impl Blake2s {
+impl<const N: usize> Blake2s<N> {
     const IV: [u32; 8] = [
         0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
         0x5be0cd19,
@@ -111,7 +127,8 @@ impl Blake2s {
     fn init(&mut self, key: Option<&[u8]>) {
         let key = key.unwrap_or_default();
         let kk = key.len().min(32);
-        self.h[0] ^= 0x01010000 ^ ((kk as u32) << 8) ^ 32;
+        let nn = N.min(32);
+        self.h[0] ^= 0x01010000 ^ ((kk as u32) << 8) ^ (nn as u32);
         if !key.is_empty() {
             let mut block = [0u8; 64];
             block[..kk].copy_from_slice(&key[..kk]);
@@ -172,7 +189,7 @@ mod tests {
 
     #[test]
     fn test_blake2s() {
-        let digest = blake2s(b"abc");
+        let digest = blake2s256(b"abc");
         assert_eq!(
             digest,
             [

--- a/src/blake2s.rs
+++ b/src/blake2s.rs
@@ -1,6 +1,7 @@
 use crate::{
     block::Block,
-    traits::{Digest, Hasher, Init, KeyInit},
+    traits::{Digest, Hasher, Init, KeyInit, Mac},
+    verify::verify,
 };
 
 pub struct Blake2s<const N: usize> {
@@ -45,6 +46,10 @@ impl<const N: usize> Blake2s<N> {
         let mut digest = [0u8; N];
         self.finalize_into(&mut digest);
         digest
+    }
+
+    pub fn verify(self, code: &[u8; N]) -> bool {
+        verify(code, &self.finalize())
     }
 }
 
@@ -104,6 +109,12 @@ impl<const N: usize> Hasher for Blake2s<N> {
     const BLOCK_SIZE: usize = 64;
 
     type Block = [u8; 64];
+}
+
+impl<const N: usize> Mac for Blake2s<N> {
+    fn verify(self, code: &[u8; N]) -> bool {
+        self.verify(code)
+    }
 }
 
 impl<const N: usize> Blake2s<N> {


### PR DESCRIPTION
This PR adds variable output size support for BLAKE2b and BLAKE2s implementations.